### PR TITLE
Add key repeat

### DIFF
--- a/pad4pi/rpi_gpio.py
+++ b/pad4pi/rpi_gpio.py
@@ -2,12 +2,15 @@
 
 import RPi.GPIO as GPIO
 import time
+from threading import Timer
 
 DEFAULT_KEY_DELAY = 300
+DEFAULT_REPEAT_DELAY = 1.0
+DEFAULT_REPEAT_RATE = 1.0
 
 class KeypadFactory():
 
-    def create_keypad(self, keypad=None, row_pins=None, col_pins=None, key_delay=DEFAULT_KEY_DELAY):
+    def create_keypad(self, keypad=None, row_pins=None, col_pins=None, key_delay=DEFAULT_KEY_DELAY, repeat=False, repeat_delay=None, repeat_rate=None):
 
         if keypad is None:
             keypad = [
@@ -23,7 +26,7 @@ class KeypadFactory():
         if col_pins is None:
             col_pins = [18,27,22]
 
-        return Keypad(keypad, row_pins, col_pins, key_delay)
+        return Keypad(keypad, row_pins, col_pins, key_delay, repeat, repeat_delay, repeat_rate)
 
     def create_4_by_3_keypad(self):
 
@@ -54,15 +57,30 @@ class KeypadFactory():
         return self.create_keypad(KEYPAD, ROW_PINS, COL_PINS)
 
 class Keypad():
-    def __init__(self, keypad, row_pins, col_pins, key_delay=DEFAULT_KEY_DELAY):
+    def __init__(self, keypad, row_pins, col_pins, key_delay=DEFAULT_KEY_DELAY, repeat=False, repeat_delay=None, repeat_rate=None):
         self._handlers = []
 
         self._keypad = keypad
         self._row_pins = row_pins
         self._col_pins = col_pins
         self._key_delay = key_delay
+        self._repeat = repeat
+        self._repeat_delay = repeat_delay
+        self._repeat_rate = repeat_rate
+        self._repeat_timer = None
+        if repeat:
+            self._repeat_delay = repeat_delay if repeat_delay is not None else DEFAULT_REPEAT_DELAY
+            self._repeat_rate = repeat_rate if repeat_rate is not None else DEFAULT_REPEAT_RATE
+        else:
+            if repeat_delay is not None:
+                self._repeat = True
+                self._repeat_rate = repeat_rate if repeat_rate is not None else DEFAULT_REPEAT_RATE
+            elif repeat_rate is not None:
+                self._repeat = True
+                self._repeat_delay = repeat_delay if repeat_delay is not None else DEFAULT_REPEAT_DELAY
 
         self._last_key_press_time = 0
+        self._first_repeat = True
 
         GPIO.setmode(GPIO.BCM)
 
@@ -78,6 +96,10 @@ class Keypad():
     def clearKeyPressHandlers(self):
         self._handlers = []
 
+    def _repeatTimer(self):
+        self._repeat_timer = None
+        self._onKeyPress(None)
+
     def _onKeyPress(self, channel):
         currTime = self.getTimeInMillis()
         if currTime < self._last_key_press_time + self._key_delay:
@@ -88,6 +110,15 @@ class Keypad():
             for handler in self._handlers:
                 handler(keyPressed)
             self._last_key_press_time = currTime
+            if self._repeat:
+                self._repeat_timer = Timer(self._repeat_delay if self._first_repeat else 1.0/self._repeat_rate, self._repeatTimer)
+                self._first_repeat = False
+                self._repeat_timer.start()
+        else:
+            if self._repeat_timer is not None:
+                self._repeat_timer.cancel()
+            self._repeat_timer = None
+            self._first_repeat = True
 
     def _setRowsAsInput(self):
         # Set all rows as input
@@ -129,7 +160,28 @@ class Keypad():
         return keyVal
 
     def cleanup(self):
+        if self._repeat_timer is not None:
+            self._repeat_timer.cancel()
         GPIO.cleanup()
 
     def getTimeInMillis(self):
         return time.time() * 1000
+
+if __name__ == "__main__":
+    from pad4pi import rpi_gpio
+
+    KEYPAD = [
+        ["F1", "F2", "#", "*"],
+        [1, 2, 3, "Up"],
+        [4, 5, 6, "Down"],
+        [7, 8, 9, "Esc"],
+        ["Left", 0, "Right", "Ent"]
+        ]
+    ROW_PINS = [4, 17, 18, 27, 22]
+    COL_PINS = [9, 10, 24, 23]
+    kp = rpi_gpio.KeypadFactory().create_keypad(keypad=KEYPAD, row_pins=ROW_PINS, col_pins=COL_PINS, repeat=True, repeat_rate=5, key_delay=100)
+    def printkey(key):
+        print(key)
+    kp.registerKeyPressHandler(printkey)
+    i = raw_input('')
+    kp.cleanup()


### PR DESCRIPTION
Add support for key repeat using threading.Timer.
Additional arguments to constructor:
- repeat=False, set to True to enable key repeat with default delay and rate
- repeat_delay=None, defaults to 1 second delay before starting key repeat
- repeat_rate=None, defaults to 1 per second

key_delay may conflict with repeat_delay. Set key_delay to less than 1/repeat_rate * 1000 to avoid conflict.